### PR TITLE
Handle cases where ng is inaccessible

### DIFF
--- a/public/docdef.ts
+++ b/public/docdef.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 import { fieldFormats } from 'ui/registry/field_formats';
-import { ngApi } from "./field-formatters";
+import { ngApi } from './field-formatters';
 
 export function DocDefNameProvider(FieldFormat: any) {
     return class DocDefName extends FieldFormat {

--- a/public/field-formatters.ts
+++ b/public/field-formatters.ts
@@ -24,24 +24,31 @@ class NGAPI {
     private definitions!: Record<DefinitionType, Definition[]>;
 
     async init(): Promise<void> {
-        const baseUrl = getParameterByName('ng-url');
-        const ajaxSettings: JQuery.AjaxSettings = {
-            type: 'GET',
-            dataType: 'json',
-
-            accepts: { json: 'application/json' },
-            xhrFields: {
-                withCredentials: true
+        try {
+            const baseUrl = getParameterByName('ng-url');
+            if (!baseUrl) {
+                throw new Error('No base URL provided');
             }
-        };
+            const ajaxSettings: JQuery.AjaxSettings = {
+                type: 'GET',
+                dataType: 'json',
 
-        const [ docDefs, users, filters ] = await Promise.all([
-            $.ajax(baseUrl + '/api/definitions', ajaxSettings),
-            $.ajax(baseUrl + '/api/definitions/users', ajaxSettings),
-            $.ajax(baseUrl + '/api/filters', ajaxSettings)
-        ]);
+                accepts: { json: 'application/json' },
+                xhrFields: {
+                    withCredentials: true
+                }
+            };
 
-        this.definitions = { docDefs, filters, users };
+            const [docDefs, users, filters] = await Promise.all([
+                $.ajax(baseUrl + '/api/definitions', ajaxSettings),
+                $.ajax(baseUrl + '/api/definitions/users', ajaxSettings),
+                $.ajax(baseUrl + '/api/filters', ajaxSettings)
+            ]);
+
+            this.definitions = {docDefs, filters, users};
+        } catch(error) {
+            console.log(error);
+        }
     }
 
     convert(type: DefinitionType, value: string | number): string | undefined {

--- a/public/init-hack.ts
+++ b/public/init-hack.ts
@@ -1,5 +1,5 @@
 import uiRoutes from 'ui/routes';
-import { ngApi } from "./field-formatters";
+import { ngApi } from './field-formatters';
 
 async function setupS4iNGPlugin() {
     await ngApi.init();

--- a/public/search.ts
+++ b/public/search.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 import { fieldFormats } from 'ui/registry/field_formats';
-import {ngApi} from './field-formatters';
+import { ngApi } from './field-formatters';
 
 export function SearchNameProvider(FieldFormat: any) {
     return class SearchName extends FieldFormat {

--- a/public/user.ts
+++ b/public/user.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 import { fieldFormats } from 'ui/registry/field_formats';
-import {ngApi} from './field-formatters';
+import { ngApi } from './field-formatters';
 
 export function UserNameProvider(FieldFormat: any) {
     return class UserName extends FieldFormat {


### PR DESCRIPTION
This PR addresses situations where the plugin's request to NG fails, either because it doesn't have the correct URL or because nothing comes back. 